### PR TITLE
Make rpc a io.ReadWriter

### DIFF
--- a/p2p/tcp_transport.go
+++ b/p2p/tcp_transport.go
@@ -138,7 +138,7 @@ func (u *TcpTransport) handleConn(conn net.Conn) error {
 		}
 		rpc.From = conn.RemoteAddr()
 		u.rpcCh <- rpc
-		u.logger.Debug("got rpc", zap.Any("raw", rpc), zap.String("payload", string(rpc.Payload)))
+		u.logger.Debug("got rpc", zap.Any("raw", rpc), zap.String("payload", string(rpc.payload)))
 	}
 
 	return nil


### PR DESCRIPTION
Figured out that large streaming files would break the rpc layer because they would require buffering the entire file content

transform rpc into reader-writer and add first cut of stream copy. need to revisit the error handling there and add tests